### PR TITLE
127 fix makerspace components styling

### DIFF
--- a/siths-redesign/components/FullArticle.vue
+++ b/siths-redesign/components/FullArticle.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    v-if="article"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+    @click="$emit('close')"
+  >
+    <div
+      class="flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl bg-white text-black shadow-2xl"
+      @click.stop
+    >
+      <div class="border-gray-200 flex items-start justify-between border-b p-6">
+        <h2 class="text-gray-900 pr-4 text-2xl font-bold">{{ article.headline }}</h2>
+        <button
+          @click="$emit('close')"
+          class="text-gray-400 hover:text-gray-600 p-1 transition-colors hover:cursor-pointer"
+        ></button>
+      </div>
+      <div class="flex-1 overflow-y-auto p-6">
+        <img
+          v-if="article.imageUrl"
+          :src="article.imageUrl"
+          :alt="article.headline"
+          class="mb-6 h-64 w-full rounded-lg object-cover"
+        />
+        <p class="text-gray-700 whitespace-pre-wrap text-base leading-relaxed">
+          {{ article.fullContent }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  article: {
+    type: Object,
+    default: null
+  }
+})
+
+defineEmits(['close'])
+</script>

--- a/siths-redesign/components/FullArticle.vue
+++ b/siths-redesign/components/FullArticle.vue
@@ -9,17 +9,20 @@
       @click.stop
     >
       <div class="border-gray-200 flex items-start justify-between border-b p-6">
-        <h2 class="text-gray-900 pr-4 text-2xl font-bold">{{ article.headline }}</h2>
+        <h2 class="pr-4 text-2xl font-bold text-gray-900">{{ article.headline }}</h2>
         <button
           @click="$emit('close')"
-          class="text-gray-400 hover:text-gray-600 p-1 transition-colors hover:cursor-pointer"
-        ></button>
+          class="p-1 opacity-50 hover:opacity-80 transition-opacity hover:cursor-pointer"
+          aria-label="Close"
+        >
+          <img src="~/assets/icons/x.png" alt="Close" class="h-5 w-5" />
+        </button>
       </div>
       <div class="flex-1 overflow-y-auto p-6">
         <img
           v-if="article.imageUrl"
           :src="article.imageUrl"
-          :alt="article.headline"
+          :alt="`Featured image for article: ${article.headline}`"
           class="mb-6 h-64 w-full rounded-lg object-cover"
         />
         <p class="text-gray-700 whitespace-pre-wrap text-base leading-relaxed">
@@ -34,7 +37,7 @@
 defineProps({
   article: {
     type: Object,
-    default: null
+    required: true,
   }
 })
 

--- a/siths-redesign/components/MakerspaceGrid.vue
+++ b/siths-redesign/components/MakerspaceGrid.vue
@@ -1,93 +1,71 @@
 <template>
   <div class="w-full px-4 lg:w-3/5 xl:w-3/6">
     <div class="flex flex-col gap-6">
-      <div
-        v-for="article in paginatedArticles"
-        :key="article._id"
-        :is="article.externalLink ? 'a' : 'div'"
-        :href="article.externalLink || undefined"
-        :target="article.externalLink ? '_blank' : undefined"
+      <div v-for="article in paginatedArticles" :key="article._id" :is="article.externalLink ? 'a' : 'div'"
+        :href="article.externalLink || undefined" :target="article.externalLink ? '_blank' : undefined"
         :rel="article.externalLink ? 'noopener noreferrer' : undefined"
-        :class="article.externalLink ? 'group cursor-pointer' : ''"
-      >
-        <div
-          :class="[
-            'flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 md:flex-row',
-            article.externalLink ? 'hover:shadow-2xl' : ''
-          ]"
-        >
-          <div
-            v-if="article.imageUrl"
-            class="h-64 w-full flex-shrink-0 overflow-hidden md:h-auto md:w-1/3 lg:w-2/5"
-          >
-            <img
-              :src="article.imageUrl"
-              :alt="article.headline"
-              :class="[
-                'h-full w-full object-cover transition-transform duration-300',
-                article.externalLink ? 'group-hover:scale-105' : ''
-              ]"
-            />
+        :class="article.externalLink ? 'group cursor-pointer' : ''" @click="showArticlePopup = true">
+        <div :class="[
+          'flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 md:flex-row',
+          article.externalLink ? 'hover:shadow-2xl' : ''
+        ]">
+          <div v-if="article.imageUrl" class="h-64 w-full flex-shrink-0 overflow-hidden md:h-auto md:w-1/3 lg:w-2/5">
+            <img :src="article.imageUrl" :alt="article.headline" :class="[
+              'h-full w-full object-cover transition-transform duration-300',
+              article.externalLink ? 'group-hover:scale-105' : ''
+            ]" />
           </div>
           <div class="flex flex-grow flex-col justify-between p-6 md:p-8">
             <div>
-              <h3
-                :class="[
-                  'mb-3 flex items-start justify-between gap-2 text-xl font-semibold transition-colors duration-300 md:text-2xl'
-                ]"
-              >
+              <h3 :class="[
+                'mb-3 flex items-start justify-between gap-2 text-xl font-semibold transition-colors duration-300 md:text-2xl'
+              ]">
                 <span class="flex-1">{{ article.headline }}</span>
-                <img
-                  v-if="article.externalLink"
-                  src="../assets/icons/xlink.png"
-                  alt="external link"
-                  class="inline h-5 flex-shrink-0"
-                />
+                <img v-if="article.externalLink" src="../assets/icons/xlink.png" alt="external link"
+                  class="inline h-5 flex-shrink-0" />
               </h3>
               <p class="text-gray-700 whitespace-pre-wrap text-base leading-relaxed">
                 {{ article.fullContent }}
               </p>
             </div>
-            <a
-              v-if="article.externalLink"
-              :href="article.externalLink"
-              target="_blank"
-              class="mt-4 text-sm font-semibold text-gold group-hover:underline"
-            >
+            <a v-if="article.externalLink" :href="article.externalLink" target="_blank"
+              class="mt-4 text-sm font-semibold text-gold group-hover:underline">
               Read More →
             </a>
           </div>
         </div>
       </div>
     </div>
+    <div v-if="showArticlePopup"
+      class="fixed inset-0 backdrop-blur-sm bg-opacity-50 flex items-center justify-center z-50" @click="closePopup">
+      <div class="border-2 border-gray-200 bg-white rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto"
+        @click.stop>
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-xl font-bold">Filter Instruments</h2>
+          <button @click="showArticlePopup = false" class="text-gray-600 hover:text-gray-800 hover:cursor-pointer">
+            Close
+          </button>
+        </div>
+        <instrumentFilter @close="showArticlePopup = false" />
+      </div>
+    </div>
     <div v-if="totalPages > 1" class="mt-8 flex w-full items-center justify-center gap-4">
-      <button
-        @click="currentPage > 1 ? previousPage() : null"
-        :class="[
-          'btn inline-flex',
-          currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-        ]"
-      >
+      <button @click="currentPage > 1 ? previousPage() : null" :class="[
+        'btn inline-flex',
+        currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+      ]">
         ← Previous
       </button>
       <div class="flex gap-2">
-        <button
-          v-for="page in totalPages"
-          :key="page"
-          @click="goToPage(page)"
-          :class="{ 'btn-active': currentPage === page }"
-          class="btn join-item"
-        >
+        <button v-for="page in totalPages" :key="page" @click="goToPage(page)"
+          :class="{ 'btn-active': currentPage === page }" class="btn join-item">
           {{ page }}
         </button>
       </div>
-      <button
-        @click="currentPage < totalPages ? nextPage() : null"
-        :class="[
-          'btn inline-flex',
-          currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-        ]"
-      >
+      <button @click="currentPage < totalPages ? nextPage() : null" :class="[
+        'btn inline-flex',
+        currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+      ]">
         Next →
       </button>
     </div>

--- a/siths-redesign/components/MakerspaceGrid.vue
+++ b/siths-redesign/components/MakerspaceGrid.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="w-full px-4 lg:w-3/5 xl:w-3/6">
+  <div class="w-full px-4 lg:w-3/5 xl:w-1/2">
     <div class="flex flex-col gap-6">
-      <a
-        v-for="article in paginatedArticles.filter((a) => a.externalLink)"
+      <component
+        :is="article.externalLink ? 'a' : 'div'"
+        v-for="article in paginatedArticles"
         :key="article._id"
-        :href="article.externalLink"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="group cursor-pointer"
+        :href="article.externalLink || undefined"
+        :target="article.externalLink ? '_blank' : undefined"
+        :rel="article.externalLink ? 'noopener noreferrer' : undefined"
+        class="group"
+        @click="!article.externalLink && openArticle(article)"
       >
         <div
           class="flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 hover:shadow-2xl md:flex-row"
@@ -29,6 +31,7 @@
               >
                 <span class="flex-1">{{ article.headline }}</span>
                 <img
+                  v-if="article.externalLink"
                   src="../assets/icons/xlink.png"
                   alt="external link"
                   class="inline h-5 flex-shrink-0"
@@ -43,43 +46,7 @@
             </div>
           </div>
         </div>
-      </a>
-      <div
-        v-for="article in paginatedArticles.filter((a) => !a.externalLink)"
-        :key="article._id"
-        class="group cursor-pointer"
-        @click="openArticle(article)"
-      >
-        <div
-          class="flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 hover:shadow-2xl md:flex-row"
-        >
-          <div
-            v-if="article.imageUrl"
-            class="h-64 w-full flex-shrink-0 overflow-hidden md:h-auto md:w-1/3 lg:w-2/5"
-          >
-            <img
-              :src="article.imageUrl"
-              :alt="article.headline"
-              class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-            />
-          </div>
-          <div class="flex flex-grow flex-col justify-between p-6 md:p-8">
-            <div>
-              <h3
-                class="mb-3 flex items-start justify-between gap-2 text-xl font-semibold transition-colors duration-300 md:text-2xl"
-              >
-                <span class="flex-1">{{ article.headline }}</span>
-              </h3>
-              <p class="text-gray-700 text-base leading-relaxed">
-                {{ truncateText(article.fullContent, 150) }}
-              </p>
-            </div>
-            <div class="mt-4 text-sm font-semibold text-gold group-hover:underline">
-              Read More →
-            </div>
-          </div>
-        </div>
-      </div>
+      </component>
     </div>
     <FullArticle :article="selectedArticle" @close="selectedArticle = null" />
     <Pagination
@@ -93,9 +60,6 @@
 </template>
 
 <script setup>
-import FullArticle from './FullArticle.vue'
-import Pagination from './Pagination.vue'
-
 const props = defineProps({
   articles: {
     type: Array,

--- a/siths-redesign/components/MakerspaceGrid.vue
+++ b/siths-redesign/components/MakerspaceGrid.vue
@@ -1,71 +1,143 @@
 <template>
   <div class="w-full px-4 lg:w-3/5 xl:w-3/6">
     <div class="flex flex-col gap-6">
-      <div v-for="article in paginatedArticles" :key="article._id" :is="article.externalLink ? 'a' : 'div'"
-        :href="article.externalLink || undefined" :target="article.externalLink ? '_blank' : undefined"
-        :rel="article.externalLink ? 'noopener noreferrer' : undefined"
-        :class="article.externalLink ? 'group cursor-pointer' : ''" @click="showArticlePopup = true">
-        <div :class="[
-          'flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 md:flex-row',
-          article.externalLink ? 'hover:shadow-2xl' : ''
-        ]">
-          <div v-if="article.imageUrl" class="h-64 w-full flex-shrink-0 overflow-hidden md:h-auto md:w-1/3 lg:w-2/5">
-            <img :src="article.imageUrl" :alt="article.headline" :class="[
-              'h-full w-full object-cover transition-transform duration-300',
-              article.externalLink ? 'group-hover:scale-105' : ''
-            ]" />
+      <a
+        v-for="article in paginatedArticles.filter((a) => a.externalLink)"
+        :key="article._id"
+        :href="article.externalLink"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group cursor-pointer"
+      >
+        <div
+          class="flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 hover:shadow-2xl md:flex-row"
+        >
+          <div
+            v-if="article.imageUrl"
+            class="h-64 w-full flex-shrink-0 overflow-hidden md:h-auto md:w-1/3 lg:w-2/5"
+          >
+            <img
+              :src="article.imageUrl"
+              :alt="article.headline"
+              class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            />
           </div>
           <div class="flex flex-grow flex-col justify-between p-6 md:p-8">
             <div>
-              <h3 :class="[
-                'mb-3 flex items-start justify-between gap-2 text-xl font-semibold transition-colors duration-300 md:text-2xl'
-              ]">
+              <h3
+                class="mb-3 flex items-start justify-between gap-2 text-xl font-semibold transition-colors duration-300 md:text-2xl"
+              >
                 <span class="flex-1">{{ article.headline }}</span>
-                <img v-if="article.externalLink" src="../assets/icons/xlink.png" alt="external link"
-                  class="inline h-5 flex-shrink-0" />
+                <img
+                  src="../assets/icons/xlink.png"
+                  alt="external link"
+                  class="inline h-5 flex-shrink-0"
+                />
               </h3>
-              <p class="text-gray-700 whitespace-pre-wrap text-base leading-relaxed">
-                {{ article.fullContent }}
+              <p class="text-gray-700 text-base leading-relaxed">
+                {{ truncateText(article.fullContent, 150) }}
               </p>
             </div>
-            <a v-if="article.externalLink" :href="article.externalLink" target="_blank"
-              class="mt-4 text-sm font-semibold text-gold group-hover:underline">
+            <div class="mt-4 text-sm font-semibold text-gold group-hover:underline">
               Read More →
-            </a>
+            </div>
+          </div>
+        </div>
+      </a>
+      <div
+        v-for="article in paginatedArticles.filter((a) => !a.externalLink)"
+        :key="article._id"
+        class="group cursor-pointer"
+        @click="openArticle(article)"
+      >
+        <div
+          class="flex flex-col overflow-hidden rounded-lg bg-white text-black shadow-lg transition-all duration-300 hover:shadow-2xl md:flex-row"
+        >
+          <div
+            v-if="article.imageUrl"
+            class="h-64 w-full flex-shrink-0 overflow-hidden md:h-auto md:w-1/3 lg:w-2/5"
+          >
+            <img
+              :src="article.imageUrl"
+              :alt="article.headline"
+              class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            />
+          </div>
+          <div class="flex flex-grow flex-col justify-between p-6 md:p-8">
+            <div>
+              <h3
+                class="mb-3 flex items-start justify-between gap-2 text-xl font-semibold transition-colors duration-300 md:text-2xl"
+              >
+                <span class="flex-1">{{ article.headline }}</span>
+              </h3>
+              <p class="text-gray-700 text-base leading-relaxed">
+                {{ truncateText(article.fullContent, 150) }}
+              </p>
+            </div>
+            <div class="mt-4 text-sm font-semibold text-gold group-hover:underline">
+              Read More →
+            </div>
           </div>
         </div>
       </div>
     </div>
-    <div v-if="showArticlePopup"
-      class="fixed inset-0 backdrop-blur-sm bg-opacity-50 flex items-center justify-center z-50" @click="closePopup">
-      <div class="border-2 border-gray-200 bg-white rounded-lg p-6 max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto"
-        @click.stop>
-        <div class="flex justify-between items-center mb-4">
-          <h2 class="text-xl font-bold">Filter Instruments</h2>
-          <button @click="showArticlePopup = false" class="text-gray-600 hover:text-gray-800 hover:cursor-pointer">
-            Close
-          </button>
+    <div
+      v-if="selectedArticle"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      @click="selectedArticle = null"
+    >
+      <div
+        class="flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl bg-white text-black shadow-2xl"
+        @click.stop
+      >
+        <div class="border-gray-200 flex items-start justify-between border-b p-6">
+          <h2 class="text-gray-900 pr-4 text-2xl font-bold">{{ selectedArticle.headline }}</h2>
+          <button
+            @click="selectedArticle = null"
+            class="text-gray-400 hover:text-gray-600 p-1 transition-colors hover:cursor-pointer"
+          ></button>
         </div>
-        <instrumentFilter @close="showArticlePopup = false" />
+        <div class="flex-1 overflow-y-auto p-6">
+          <img
+            v-if="selectedArticle.imageUrl"
+            :src="selectedArticle.imageUrl"
+            :alt="selectedArticle.headline"
+            class="mb-6 h-64 w-full rounded-lg object-cover"
+          />
+          <p class="text-gray-700 whitespace-pre-wrap text-base leading-relaxed">
+            {{ selectedArticle.fullContent }}
+          </p>
+        </div>
       </div>
     </div>
     <div v-if="totalPages > 1" class="mt-8 flex w-full items-center justify-center gap-4">
-      <button @click="currentPage > 1 ? previousPage() : null" :class="[
-        'btn inline-flex',
-        currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-      ]">
+      <button
+        @click="currentPage > 1 ? previousPage() : null"
+        :class="[
+          'btn inline-flex',
+          currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+        ]"
+      >
         ← Previous
       </button>
       <div class="flex gap-2">
-        <button v-for="page in totalPages" :key="page" @click="goToPage(page)"
-          :class="{ 'btn-active': currentPage === page }" class="btn join-item">
+        <button
+          v-for="page in totalPages"
+          :key="page"
+          @click="goToPage(page)"
+          :class="{ 'btn-active': currentPage === page }"
+          class="btn join-item"
+        >
           {{ page }}
         </button>
       </div>
-      <button @click="currentPage < totalPages ? nextPage() : null" :class="[
-        'btn inline-flex',
-        currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-      ]">
+      <button
+        @click="currentPage < totalPages ? nextPage() : null"
+        :class="[
+          'btn inline-flex',
+          currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+        ]"
+      >
         Next →
       </button>
     </div>
@@ -83,12 +155,15 @@ const props = defineProps({
     default: 5
   }
 })
+const selectedArticle = ref(null)
 
-const showArticlePopup = ref(false)
-const closePopup = (event) => {
-  if (event.target === event.currentTarget) {
-    showFilterPopup.value = false
-  }
+function openArticle(article) {
+  selectedArticle.value = article
+}
+
+function truncateText(text, maxLength) {
+  if (!text || text.length <= maxLength) return text
+  return text.slice(0, maxLength).trim() + '...'
 }
 
 const currentPage = ref(1)

--- a/siths-redesign/components/MakerspaceGrid.vue
+++ b/siths-redesign/components/MakerspaceGrid.vue
@@ -81,70 +81,21 @@
         </div>
       </div>
     </div>
-    <div
-      v-if="selectedArticle"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
-      @click="selectedArticle = null"
-    >
-      <div
-        class="flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl bg-white text-black shadow-2xl"
-        @click.stop
-      >
-        <div class="border-gray-200 flex items-start justify-between border-b p-6">
-          <h2 class="text-gray-900 pr-4 text-2xl font-bold">{{ selectedArticle.headline }}</h2>
-          <button
-            @click="selectedArticle = null"
-            class="text-gray-400 hover:text-gray-600 p-1 transition-colors hover:cursor-pointer"
-          ></button>
-        </div>
-        <div class="flex-1 overflow-y-auto p-6">
-          <img
-            v-if="selectedArticle.imageUrl"
-            :src="selectedArticle.imageUrl"
-            :alt="selectedArticle.headline"
-            class="mb-6 h-64 w-full rounded-lg object-cover"
-          />
-          <p class="text-gray-700 whitespace-pre-wrap text-base leading-relaxed">
-            {{ selectedArticle.fullContent }}
-          </p>
-        </div>
-      </div>
-    </div>
-    <div v-if="totalPages > 1" class="mt-8 flex w-full items-center justify-center gap-4">
-      <button
-        @click="currentPage > 1 ? previousPage() : null"
-        :class="[
-          'btn inline-flex',
-          currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-        ]"
-      >
-        ← Previous
-      </button>
-      <div class="flex gap-2">
-        <button
-          v-for="page in totalPages"
-          :key="page"
-          @click="goToPage(page)"
-          :class="{ 'btn-active': currentPage === page }"
-          class="btn join-item"
-        >
-          {{ page }}
-        </button>
-      </div>
-      <button
-        @click="currentPage < totalPages ? nextPage() : null"
-        :class="[
-          'btn inline-flex',
-          currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-        ]"
-      >
-        Next →
-      </button>
-    </div>
+    <FullArticle :article="selectedArticle" @close="selectedArticle = null" />
+    <Pagination
+      :current-page="currentPage"
+      :total-pages="totalPages"
+      @previous="previousPage"
+      @next="nextPage"
+      @go-to="goToPage"
+    />
   </div>
 </template>
 
 <script setup>
+import FullArticle from './FullArticle.vue'
+import Pagination from './Pagination.vue'
+
 const props = defineProps({
   articles: {
     type: Array,

--- a/siths-redesign/components/MakerspaceGrid.vue
+++ b/siths-redesign/components/MakerspaceGrid.vue
@@ -84,6 +84,13 @@ const props = defineProps({
   }
 })
 
+const showArticlePopup = ref(false)
+const closePopup = (event) => {
+  if (event.target === event.currentTarget) {
+    showFilterPopup.value = false
+  }
+}
+
 const currentPage = ref(1)
 const totalPages = computed(function () {
   return Math.ceil(props.articles.length / props.articlesPerPage)

--- a/siths-redesign/components/Pagination.vue
+++ b/siths-redesign/components/Pagination.vue
@@ -1,0 +1,48 @@
+<template>
+  <div v-if="totalPages > 1" class="mt-8 flex w-full items-center justify-center gap-4">
+    <button
+      @click="currentPage > 1 ? $emit('previous') : null"
+      :class="[
+        'btn inline-flex',
+        currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+      ]"
+    >
+      ← Previous
+    </button>
+    <div class="flex gap-2">
+      <button
+        v-for="page in totalPages"
+        :key="page"
+        @click="$emit('go-to', page)"
+        :class="{ 'btn-active': currentPage === page }"
+        class="btn join-item"
+      >
+        {{ page }}
+      </button>
+    </div>
+    <button
+      @click="currentPage < totalPages ? $emit('next') : null"
+      :class="[
+        'btn inline-flex',
+        currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+      ]"
+    >
+      Next →
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  currentPage: {
+    type: Number,
+    required: true
+  },
+  totalPages: {
+    type: Number,
+    required: true
+  }
+})
+
+defineEmits(['previous', 'next', 'go-to'])
+</script>

--- a/siths-redesign/components/Pagination.vue
+++ b/siths-redesign/components/Pagination.vue
@@ -2,8 +2,8 @@
   <div v-if="totalPages > 1" class="mt-8 flex w-full items-center justify-center gap-4">
     <button
       @click="$emit('previous')"
-      :disabled="currentPage === 1"
-      class="btn inline-flex disabled:cursor-not-allowed disabled:opacity-50"
+      class="btn inline-flex"
+      :class="[currentPage === 1 && 'pointer-events-none opacity-80']"
     >
       ← Previous
     </button>
@@ -12,17 +12,16 @@
         v-for="page in totalPages"
         :key="page"
         @click="$emit('go-to', page)"
-        :disabled="currentPage === page"
-        :class="{ 'btn-active': currentPage === page }"
         class="btn join-item"
+        :class="{ 'btn-active': currentPage === page }"
       >
         {{ page }}
       </button>
     </div>
     <button
       @click="$emit('next')"
-      :disabled="currentPage === totalPages"
-      class="btn inline-flex disabled:cursor-not-allowed disabled:opacity-50"
+      class="btn inline-flex"
+      :class="[currentPage === totalPages && 'pointer-events-none opacity-80']"
     >
       Next →
     </button>

--- a/siths-redesign/components/Pagination.vue
+++ b/siths-redesign/components/Pagination.vue
@@ -1,11 +1,9 @@
 <template>
   <div v-if="totalPages > 1" class="mt-8 flex w-full items-center justify-center gap-4">
     <button
-      @click="currentPage > 1 ? $emit('previous') : null"
-      :class="[
-        'btn inline-flex',
-        currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-      ]"
+      @click="$emit('previous')"
+      :disabled="currentPage === 1"
+      class="btn inline-flex disabled:cursor-not-allowed disabled:opacity-50"
     >
       ← Previous
     </button>
@@ -14,6 +12,7 @@
         v-for="page in totalPages"
         :key="page"
         @click="$emit('go-to', page)"
+        :disabled="currentPage === page"
         :class="{ 'btn-active': currentPage === page }"
         class="btn join-item"
       >
@@ -21,11 +20,9 @@
       </button>
     </div>
     <button
-      @click="currentPage < totalPages ? $emit('next') : null"
-      :class="[
-        'btn inline-flex',
-        currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-      ]"
+      @click="$emit('next')"
+      :disabled="currentPage === totalPages"
+      class="btn inline-flex disabled:cursor-not-allowed disabled:opacity-50"
     >
       Next →
     </button>

--- a/siths-redesign/pages/cte/makerspace.vue
+++ b/siths-redesign/pages/cte/makerspace.vue
@@ -1,6 +1,7 @@
 <template>
     <h1 class="mb-4 text-center text-2xl md:text-3xl lg:text-4xl">Career and Technical Education</h1>
     <div class="mb-6 flex flex-col items-start justify-center px-4 md:flex-row">
+        <SubpageMenu :pages="cteLinks" :active="'About'" class="block mb-4 lg:absolute left-8 top-40" />
         <div class="flex w-full flex-col items-center justify-center">
             <h2 class="mb-4 text-xl md:mb-8 md:text-2xl">Makerspace</h2>
             <MakerspaceGrid :articles="websiteData.makerspace" />

--- a/siths-redesign/pages/cte/makerspace.vue
+++ b/siths-redesign/pages/cte/makerspace.vue
@@ -4,7 +4,7 @@
   </h1>
 
   <div class="flex flex-col items-start justify-center px-4 md:flex-row">
-    <SubpageMenu :pages="cteLinks" :active="'Makerspace'" class="left-8 top-40 mb-4 block" />
+    <SubpageMenu :pages="cteLinks" active="Makerspace" class="left-8 top-40 mb-4 block" />
     <div class="flex w-full flex-col items-center justify-center">
       <h2 class="mb-4 text-xl md:mb-8 md:text-2xl">Makerspace</h2>
       <MakerspaceGrid :articles="websiteData.makerspace" />


### PR DESCRIPTION
made it so that articles just display image, headline, and short portion of text (if too much text, it gets cut off by ...)
when user clicks on article, if the article has an external link they are brought to that but if no external link, a popup appears with the full article text (scroll to read) along with the headline and image 
+ prettier code formatting